### PR TITLE
Markets/get one

### DIFF
--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -1,5 +1,22 @@
-class Api::V0::MarketsController < ApplicationController  
+class Api::V0::MarketsController < ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
   def index
-    render json: MarketSerializer.format_markets(Market.all)
+    render json: MarketSerializer.new(Market.all)
+  end
+
+  def show
+    find_market
+    render json: MarketSerializer.new(@market)
+  end
+
+  private
+  
+  def find_market
+    @market = Market.find(params[:id])
+  end
+
+  def not_found_error(exception)
+    render json: ErrorSerializer.format_error(exception), status: :not_found
   end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,11 @@
+class ErrorSerializer
+  def self.format_error(exception_error)
+    {
+      errors: [
+        {
+          detail: exception_error
+        }
+      ]
+    }
+  end
+end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -1,23 +1,4 @@
 class MarketSerializer
-  def self.format_markets(markets)
-    {
-      data: markets.map do |market|
-        {
-          id: market.id,
-          type: "market",
-          attributes: {
-            name: market.name,
-            street: market.street,
-            city: market.city,
-            county: market.county,
-            state: market.state,
-            zip: market.zip,
-            lat: market.lat,
-            lon: market.lon,
-            vendor_count: market.vendor_count
-          }
-        }
-      end
-    }
-  end
+  include JSONAPI::Serializer
+  attributes :name, :street, :city, :county, :state, :zip, :lat, :lon, :vendor_count
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api do
     namespace :v0 do
-      resources :markets, only: [:index]
+      resources :markets, only: [:index, :show]
       resources :vendors, only: [:show]
     end
   end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -51,4 +51,51 @@ describe "Market API" do
       expect(market[:attributes][:vendor_count]).to be_an(Integer)
     end
   end
+
+  it "can get a market by its id" do
+    market_id = create(:market).id
+
+    get "/api/v0/markets/#{id}"
+
+    expect(response).to be_successful
+
+    formatted_response = JSON.parse(response.body, symbolize_names: true)
+    market = formatted_response[:data]
+
+    expect(market).to have_key(:id)
+    expect(market[:id]).to be_an(Integer)
+
+    expect(market).to have_key(:type)
+    expect(market[:type]).to be_a(String)
+
+    expect(market).to have_key(:attributes)
+    expect(market[:attributes]).to be_a(Hash)
+
+    expect(market[:attributes]).to have_key(:name)
+    expect(market[:attributes][:name]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:street)
+    expect(market[:attributes][:street]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:city)
+    expect(market[:attributes][:city]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:county)
+    expect(market[:attributes][:county]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:state)
+    expect(market[:attributes][:state]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:zip)
+    expect(market[:attributes][:zip]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:lat)
+    expect(market[:attributes][:lat]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:lon)
+    expect(market[:attributes][:lon]).to be_a(String)
+
+    expect(market[:attributes]).to have_key(:vendor_count)
+    expect(market[:attributes][:vendor_count]).to be_an(Integer)
+  end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -10,92 +10,46 @@ describe "Market API" do
 
     formatted_response = JSON.parse(response.body, symbolize_names: true)
     markets = formatted_response[:data]
-    
+
     expect(markets.count).to eq(5)
 
     markets.each do |market|
-      expect(market).to have_key(:id)
-      expect(market[:id]).to be_an(Integer)
+      expect(market).to include(:id, :type, :attributes)
 
-      expect(market).to have_key(:type)
+      expect(market[:id]).to be_a(String)
       expect(market[:type]).to be_a(String)
-
-      expect(market).to have_key(:attributes)
       expect(market[:attributes]).to be_a(Hash)
+      
+      expect(market[:attributes]).to include(
+        :name, :street, :city, :county, :state, :zip, :lat, :lon, :vendor_count
+      )
 
-      expect(market[:attributes]).to have_key(:name)
-      expect(market[:attributes][:name]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:street)
-      expect(market[:attributes][:street]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:city)
-      expect(market[:attributes][:city]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:county)
-      expect(market[:attributes][:county]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:state)
-      expect(market[:attributes][:state]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:zip)
-      expect(market[:attributes][:zip]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:lat)
-      expect(market[:attributes][:lat]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:lon)
-      expect(market[:attributes][:lon]).to be_a(String)
-
-      expect(market[:attributes]).to have_key(:vendor_count)
+      expect(market[:attributes].except(:vendor_count).values).to all(be_a(String))
       expect(market[:attributes][:vendor_count]).to be_an(Integer)
     end
   end
 
   it "can get a market by its id" do
-    market_id = create(:market).id
+    market_1 = create(:market)
 
-    get "/api/v0/markets/#{id}"
+    get "/api/v0/markets/#{market_1.id}"
 
     expect(response).to be_successful
 
     formatted_response = JSON.parse(response.body, symbolize_names: true)
     market = formatted_response[:data]
 
-    expect(market).to have_key(:id)
-    expect(market[:id]).to be_an(Integer)
+    expect(market).to include(:id, :type, :attributes)
 
-    expect(market).to have_key(:type)
+    expect(market[:id]).to be_a(String)
     expect(market[:type]).to be_a(String)
-
-    expect(market).to have_key(:attributes)
     expect(market[:attributes]).to be_a(Hash)
-
-    expect(market[:attributes]).to have_key(:name)
-    expect(market[:attributes][:name]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:street)
-    expect(market[:attributes][:street]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:city)
-    expect(market[:attributes][:city]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:county)
-    expect(market[:attributes][:county]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:state)
-    expect(market[:attributes][:state]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:zip)
-    expect(market[:attributes][:zip]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:lat)
-    expect(market[:attributes][:lat]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:lon)
-    expect(market[:attributes][:lon]).to be_a(String)
-
-    expect(market[:attributes]).to have_key(:vendor_count)
+    
+    expect(market[:attributes]).to include(
+      :name, :street, :city, :county, :state, :zip, :lat, :lon, :vendor_count
+    )
+    
+    expect(market[:attributes].except(:vendor_count).values).to all(be_a(String))
     expect(market[:attributes][:vendor_count]).to be_an(Integer)
   end
 
@@ -107,7 +61,6 @@ describe "Market API" do
 
     formatted_response = JSON.parse(response.body, symbolize_names: true)
     error_response = formatted_response[:errors]
-
     expect(error_response).to be_an(Array)
     expect(error_response.first).to have_key(:detail)
     expect(error_response.first[:detail]).to start_with("Couldn't find Market with 'id'=")

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -98,4 +98,18 @@ describe "Market API" do
     expect(market[:attributes]).to have_key(:vendor_count)
     expect(market[:attributes][:vendor_count]).to be_an(Integer)
   end
+
+  it "returns error message when given invalid market id" do
+    get "/api/v0/markets/1"
+
+    expect(response).to_not be_successful
+    expect(response.status).to eq 404
+
+    formatted_response = JSON.parse(response.body, symbolize_names: true)
+    error_response = formatted_response[:errors]
+
+    expect(error_response).to be_an(Array)
+    expect(error_response.first).to have_key(:detail)
+    expect(error_response.first[:detail]).to start_with("Couldn't find Market with 'id'=")
+  end
 end


### PR DESCRIPTION
**Endpoint:**
`GET /api/v0/markets/:id`

**Notable Changes:**
- refactor: MarketSerializer, market request tests
- ErrorSerializer created
- can find a market by its id

**Tests:**
Currently all passing (local & Postman)

**Issues:**
closes #4 