### PR TITLE
Markets/get all vendors

### DIFF
--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -1,8 +1,23 @@
 class Api::V0::VendorsController < ApplicationController  
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
+
+  def index
+    find_market_and_vendors
+    render json: VendorSerializer.new(@vendors)
+  end
+
   def show
     vendor = Vendor.find(params[:id])
     render json: VendorSerializer.new(vendor)
-    rescue ActiveRecord::RecordNotFound
-      render json: { errors: [{ detail: "Vendor with id=#{params[:id]} not found" }] }, status: :not_found
-    end
   end
+
+  private
+  def find_market_and_vendors
+    @market = Market.find(params[:market_id])
+    @vendors = @market.vendors
+  end
+
+  def not_found_error(exception)
+    render json: ErrorSerializer.format_error(exception), status: :not_found
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,10 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api do
     namespace :v0 do
-      resources :markets, only: [:index, :show]
       resources :vendors, only: [:show]
+      resources :markets, only: [:index, :show] do
+        resources :vendors, only: [:index]
+      end
     end
   end
 end

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -72,9 +72,11 @@ describe "Market API" do
       expect(vendor[:type]).to be_a(String)
       expect(vendor[:attributes]).to be_a(Hash)
 
-      expect(vendor[:attributes]).to have_attributes_for(:vendor)
-      expect(market[:attributes].except(:credit_accepted).values).to all(be_a(String))
-      expect(market[:attributes][:credit_accepted]).to be_a(Boolean)
+      expect(vendor[:attributes]).to include(
+        :name, :description, :contact_name, :contact_phone, :credit_accepted
+      )
+      expect(vendor[:attributes].except(:credit_accepted).values).to all(be_a(String))
+      expect(vendor[:attributes][:credit_accepted]).to be_a(FalseClass).or(be_a(TrueClass))
     end
   end
 

--- a/spec/requests/api/v0/markets_request_spec.rb
+++ b/spec/requests/api/v0/markets_request_spec.rb
@@ -53,6 +53,31 @@ describe "Market API" do
     expect(market[:attributes][:vendor_count]).to be_an(Integer)
   end
 
+  it "sends list of a market's vendors" do
+    market_1 = create(:market)
+    market_1.vendors << create_list(:vendor, 5)
+
+    get "/api/v0/markets/#{market_1.id}/vendors"
+
+    expect(response).to be_successful
+    
+    formatted_response = JSON.parse(response.body, symbolize_names: true)
+    vendors = formatted_response[:data]
+
+    expect(vendors.count).to eq(5)
+
+    vendors.each do |vendor|
+      expect(vendor).to include(:id, :type, :attributes)
+      expect(vendor[:id]).to be_a(String)
+      expect(vendor[:type]).to be_a(String)
+      expect(vendor[:attributes]).to be_a(Hash)
+
+      expect(vendor[:attributes]).to have_attributes_for(:vendor)
+      expect(market[:attributes].except(:credit_accepted).values).to all(be_a(String))
+      expect(market[:attributes][:credit_accepted]).to be_a(Boolean)
+    end
+  end
+
   it "returns error message when given invalid market id" do
     get "/api/v0/markets/1"
 

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -32,7 +32,6 @@ describe "Vendors API" do
     expect([true, false]).to include(vendor[:data][:attributes][:credit_accepted])
   end
 
-
   it "can get one vendor by its id sad path" do
     id = create(:vendor).id
   
@@ -47,6 +46,6 @@ describe "Vendors API" do
     expect(vendor[:errors]).to be_an(Array)
     expect(vendor[:errors].first).to be_a(Hash)
     expect(vendor[:errors].first).to have_key(:detail)
-    expect(vendor[:errors].first[:detail]).to include("Vendor with id=")
+    expect(vendor[:errors].first[:detail]).to include("Vendor with 'id'=")
   end
 end


### PR DESCRIPTION
**Endpoint:**
`GET /api/v0/markets/:id/vendors`

**Notable Changes:**
- refactor controllers: private methods to find market & vendor, update to use `rescue_from`
- can get a market's list of vendors

**Tests:**
Currently all passing (local & Postman)

**Issues:**
closes #3 